### PR TITLE
Always run tests with ICU data from full-icu

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,19 @@
   "scripts": {
     "build": "microbundle",
     "format": "prettier --write src/**/*",
-    "test": "jest"
+    "test": "env NODE_ICU_DATA=$(node-full-icu-path) jest"
   },
   "devDependencies": {
     "@types/jest": "^23.0.0",
     "eslint": "^4.19.1",
+    "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-shopify": "^22.1.0",
+    "full-icu": "^1.2.1",
     "jest": "^23.1.0",
     "microbundle": "^0.4.4",
     "prettier": "^1.13.4",
     "ts-jest": "^22.4.6",
-    "typescript": "^2.9.1",
-    "eslint-plugin-prettier": "^2.6.0"
+    "typescript": "^2.9.1"
   },
   "jest": {
     "transform": {

--- a/src/tests/condense-currency.test.ts
+++ b/src/tests/condense-currency.test.ts
@@ -29,7 +29,7 @@ describe('condenseCurrency()', () => {
     expect(condenseCurrency(-15000, 'ja', 'CAD')).toBe('-CA$1万');
   });
 
-  it.skip('uses Intl formatting when the locale is not supported', () => {
+  it('uses Intl formatting when the locale is not supported', () => {
     expect(condenseCurrency(150000, 'IN', 'USD')).toBe('US$150.000');
   });
 
@@ -37,7 +37,7 @@ describe('condenseCurrency()', () => {
     expect(condenseCurrency(150000, 'en', 'abc')).toBe('ABC150K');
   });
 
-  it.skip('applies precision to Intl formatting when the locale is not supported', () => {
+  it('applies precision to Intl formatting when the locale is not supported', () => {
     expect(condenseCurrency(150000, 'IN', 'USD', 2)).toBe('US$150.000,00');
   });
 });

--- a/src/tests/condense-number.test.ts
+++ b/src/tests/condense-number.test.ts
@@ -5,7 +5,7 @@ describe('condenseNumber()', () => {
     expect(condenseNumber(10, 'en')).toBe('10');
   });
 
-  it.skip('does not condense numbers when a language does not support it', () => {
+  it('does not condense numbers when a language does not support it', () => {
     expect(condenseNumber(100000, 'it')).toBe('100.000');
   });
 
@@ -17,19 +17,19 @@ describe('condenseNumber()', () => {
     expect(condenseNumber(1500000, 'de')).toBe(`1 Mio'.'`);
   });
 
-  it.skip('condenses numbers to the provided precision', () => {
+  it('condenses numbers to the provided precision', () => {
     expect(condenseNumber(1500000, 'es', 1)).toBe('1,5 M');
   });
 
-  it.skip('handles negative numbers properly', () => {
+  it('handles negative numbers properly', () => {
     expect(condenseNumber(-150000, 'ja')).toBe('-15万');
   });
 
-  it.skip('uses Intl formatting when the locale is not supported', () => {
+  it('uses Intl formatting when the locale is not supported', () => {
     expect(condenseNumber(-150000, 'IN')).toBe('-150.000');
   });
 
-  it.skip('applies precision to Intl formatting when the locale is not supported', () => {
+  it('applies precision to Intl formatting when the locale is not supported', () => {
     expect(condenseNumber(-150000, 'IN', 2)).toBe('-150.000,00');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,6 +1985,10 @@ fsevents@^1.0.0, fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
+full-icu@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.2.1.tgz#28d7f1caafb14cac262364ca584fe7f2044a4ab2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
Resolves #28 

Tests were failing on CI because not all machines run with the same ICU data. In fact, different node installations will have different amounts of locale data per https://nodejs.org/api/intl.html . This PR adds unicode's `full-icu` package and sets the ICU data path before running tests so that they run the same way in all environments.