### PR TITLE
Precision tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/condense-number",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "git@github.com:Shopify/condense-number.git",
   "author": "Shopify <dev@shopify.com>",
   "license": "MIT",

--- a/src/condense-currency.ts
+++ b/src/condense-currency.ts
@@ -11,8 +11,6 @@ export function condenseCurrency(
     return new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: currencyCode,
-      minimumFractionDigits: precision,
-      maximumFractionDigits: precision,
     }).format(value);
   }
 

--- a/src/condense-number.ts
+++ b/src/condense-number.ts
@@ -7,10 +7,7 @@ export function condenseNumber(
   precision: number = 0,
 ) {
   if (!isSupportedLocale(locale)) {
-    return new Intl.NumberFormat(locale, {
-      minimumFractionDigits: precision,
-      maximumFractionDigits: precision,
-    }).format(value);
+    return new Intl.NumberFormat(locale).format(value);
   }
 
   const {sign, number, abbreviation} = condenseNumberToParts(

--- a/src/tests/condense-currency.test.ts
+++ b/src/tests/condense-currency.test.ts
@@ -30,14 +30,14 @@ describe('condenseCurrency()', () => {
   });
 
   it('uses Intl formatting when the locale is not supported', () => {
-    expect(condenseCurrency(150000, 'IN', 'USD')).toBe('US$150.000');
+    expect(condenseCurrency(150000, 'IN', 'USD')).toBe('US$150.000,00');
   });
 
   it('falls back to the capitalized currency code when a currency symbol is not found', () => {
     expect(condenseCurrency(150000, 'en', 'abc')).toBe('ABC150K');
   });
 
-  it('applies precision to Intl formatting when the locale is not supported', () => {
-    expect(condenseCurrency(150000, 'IN', 'USD', 2)).toBe('US$150.000,00');
+  it('does not apply precision to Intl formatting when the locale is not supported', () => {
+    expect(condenseCurrency(150000, 'en-CA', 'USD', 10)).toBe('US$150,000.00');
   });
 });

--- a/src/tests/condense-number.test.ts
+++ b/src/tests/condense-number.test.ts
@@ -17,8 +17,16 @@ describe('condenseNumber()', () => {
     expect(condenseNumber(1500000, 'de')).toBe(`1 Mio'.'`);
   });
 
-  it('condenses numbers to the provided precision', () => {
+  it('rounds down', () => {
+    expect(condenseNumber(1900000, 'es')).toBe('1 M');
+  });
+
+  it('includes the provided precision when it is significant', () => {
     expect(condenseNumber(1500000, 'es', 1)).toBe('1,5 M');
+  });
+
+  it('does not include the provided precision when it is insignificant', () => {
+    expect(condenseNumber(1000000, 'es', 1)).toBe('1 M');
   });
 
   it('handles negative numbers properly', () => {
@@ -29,7 +37,7 @@ describe('condenseNumber()', () => {
     expect(condenseNumber(-150000, 'IN')).toBe('-150.000');
   });
 
-  it('applies precision to Intl formatting when the locale is not supported', () => {
-    expect(condenseNumber(-150000, 'IN', 2)).toBe('-150.000,00');
+  it('does not apply precision to Intl formatting when the locale is not supported', () => {
+    expect(condenseNumber(-150000, 'IN', 2)).toBe('-150.000');
   });
 });


### PR DESCRIPTION
- I realized what was bothering me about the precision we were applying: it doesn't make sense to apply it when we fallback to Intl formatting. So this PR removes that formatting.

- Tweaks tests accordingly.

- Also adds tests to specify some other number formatting behaviour.
