### PR TITLE
Add options object, including rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Example:
 `condenseNumber(1000, 'en')`
 = `'1K'`
 
-Optionally, provide a third parameter, which is a number and overrides the default decimal precision of 0.
+Optionally, specify maximum precision within an options object to override the default decimal precision of 0. Precision will not be applied if the decimal value is 0.
 
-`condenseNumber(1500, 'en', 1)`
+`condenseNumber(1500, 'en', {maxPrecision: 1})`
 = `'1.5K'`
 
 ### condenseCurrency
@@ -28,13 +28,35 @@ Provide a number, locale and currency code, get the value with the currency prov
 
 `condenseCurrency(15000, 'en', 'usd')` = `'$15K'`;
 
-Optionally, provide a fourth parameter, which is a number and overrides the default decimal precision of 0.
+Optionally, specify maximum precision within an options object to override the default decimal precision of 0. Precision will not be applied if the decimal value is 0.
 
-`condenseCurrency(1500, 'en', 'gbp', 1)` = `'£1.5K'`
+`condenseCurrency(1500, 'en', 'gbp', {maxPrecision: 1})` = `'£1.5K'`
 
 When a currency symbol is not found, the capitalized currency code will be used instead. For example:
 
 `condenseCurrency(150000, 'en', 'abc')` = `'ABC150K'`
+
+### Rounding
+
+By default, condensed numbers round down. For example:
+
+`condenseNumber(1500, 'en')`
+= `'1K'`
+
+However, if you want to round to the closest integer or always round up to the next integer, you can specify that in the options object, by using 'auto' or 'up':
+
+`condenseNumber(1200, 'en', {roundingRule: 'auto'})`
+= `'1K'`
+
+`condenseCurrency(1100, 'en', 'gbp', {roundingRule: 'up'})`
+
+= `'£2K'`
+
+Rounding can be used with maxPrecision.
+
+`condenseNumber(1089, 'en', {roundingRule: 'auto', maxPrecision: 1});`
+
+= `1.1K`
 
 ### How it works
 

--- a/src/condense-currency.ts
+++ b/src/condense-currency.ts
@@ -1,12 +1,19 @@
 import {formats, symbols, isSupportedLocale} from './formats';
-import {condenseNumberToParts} from './condense-number-to-parts';
+import {condenseNumberToParts, RoundingRule} from './condense-number-to-parts';
+
+interface Options {
+  maxPrecision: number;
+  roundingRule: RoundingRule;
+}
 
 export function condenseCurrency(
   value: number,
   locale: string,
   currencyCode: string,
-  precision: number = 0,
+  options: Partial<Options> = {},
 ) {
+  const {maxPrecision = 0, roundingRule = 'down'} = options;
+
   if (!isSupportedLocale(locale)) {
     return new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -17,7 +24,8 @@ export function condenseCurrency(
   const {sign, number, abbreviation} = condenseNumberToParts(
     value,
     locale,
-    precision,
+    maxPrecision,
+    roundingRule,
   );
 
   const localeInfo = formats[locale];

--- a/src/condense-number-to-parts.ts
+++ b/src/condense-number-to-parts.ts
@@ -2,6 +2,8 @@ import {formats, isSupportedLocale} from './formats';
 import {getBase} from './get-base';
 import {setPrecision} from './set-precision';
 
+export type RoundingRule = 'up' | 'down' | 'auto';
+
 interface CondensedNumberParts {
   sign: '-' | '';
   number: string;
@@ -11,7 +13,8 @@ interface CondensedNumberParts {
 export function condenseNumberToParts(
   rawValue: number,
   locale: string,
-  precision: number,
+  maxPrecision: number,
+  roundingRule: RoundingRule,
 ): CondensedNumberParts {
   const sign = rawValue < 0 ? '-' : '';
   const value = Math.abs(rawValue);
@@ -32,7 +35,12 @@ export function condenseNumberToParts(
   const zerosToRemove = condenseFormat.split('0').length - 2;
   const divideBy = base / Math.pow(10, zerosToRemove);
 
-  const number = setPrecision(value / Number(divideBy), precision);
+  const number = setPrecision(
+    value / Number(divideBy),
+    maxPrecision,
+    roundingRule,
+  );
+
   const formattedNumber = number.toLocaleString(locale);
   const abbreviation = condenseFormat.replace(/^0+/, '');
 

--- a/src/condense-number.ts
+++ b/src/condense-number.ts
@@ -1,11 +1,18 @@
 import {formats, symbols, isSupportedLocale} from './formats';
-import {condenseNumberToParts} from './condense-number-to-parts';
+import {condenseNumberToParts, RoundingRule} from './condense-number-to-parts';
+
+interface Options {
+  maxPrecision: number;
+  roundingRule: RoundingRule;
+}
 
 export function condenseNumber(
   value: number,
   locale: string,
-  precision: number = 0,
+  options: Partial<Options> = {},
 ) {
+  const {maxPrecision = 0, roundingRule = 'down'} = options;
+
   if (!isSupportedLocale(locale)) {
     return new Intl.NumberFormat(locale).format(value);
   }
@@ -13,7 +20,8 @@ export function condenseNumber(
   const {sign, number, abbreviation} = condenseNumberToParts(
     value,
     locale,
-    precision,
+    maxPrecision,
+    roundingRule,
   );
 
   const localeInfo = formats[locale];

--- a/src/set-precision.ts
+++ b/src/set-precision.ts
@@ -1,5 +1,19 @@
-export function setPrecision(value: number, precision: number) {
-  const precisionMultiplier = Math.pow(10, precision);
+import {RoundingRule} from './condense-number-to-parts';
 
-  return Math.floor(value * precisionMultiplier) / precisionMultiplier;
+export function setPrecision(
+  value: number,
+  maxPrecision: number,
+  roundingRule: RoundingRule,
+) {
+  const precisionMultiplier = Math.pow(10, maxPrecision);
+  switch (roundingRule) {
+    case 'up':
+      return Math.ceil(value * precisionMultiplier) / precisionMultiplier;
+    case 'down':
+      return Math.floor(value * precisionMultiplier) / precisionMultiplier;
+    case 'auto':
+      return Math.round(value * precisionMultiplier) / precisionMultiplier;
+    default:
+      throw new Error(`Unable to parse rounding rule: '${roundingRule}'`);
+  }
 }

--- a/src/tests/condense-currency.test.ts
+++ b/src/tests/condense-currency.test.ts
@@ -22,7 +22,25 @@ describe('condenseCurrency()', () => {
   });
 
   it('condenses numbers to the provided precision', () => {
-    expect(condenseCurrency(1500, 'en', 'gbp', 1)).toBe('£1.5K');
+    expect(condenseCurrency(1500, 'en', 'gbp', {maxPrecision: 1})).toBe(
+      '£1.5K',
+    );
+  });
+
+  it('rounds down by default', () => {
+    expect(condenseCurrency(1500, 'en', 'gbp')).toBe('£1K');
+  });
+
+  it('rounds up if specified', () => {
+    expect(condenseCurrency(1500, 'en', 'gbp', {roundingRule: 'up'})).toBe(
+      '£2K',
+    );
+  });
+
+  it('rounds automatically if specified', () => {
+    expect(condenseCurrency(1500, 'en', 'gbp', {roundingRule: 'up'})).toBe(
+      '£2K',
+    );
   });
 
   it('handles negative numbers properly', () => {
@@ -38,6 +56,8 @@ describe('condenseCurrency()', () => {
   });
 
   it('does not apply precision to Intl formatting when the locale is not supported', () => {
-    expect(condenseCurrency(150000, 'en-CA', 'USD', 10)).toBe('US$150,000.00');
+    expect(condenseCurrency(150000, 'en-CA', 'USD', {maxPrecision: 1})).toBe(
+      'US$150,000.00',
+    );
   });
 });

--- a/src/tests/condense-number.test.ts
+++ b/src/tests/condense-number.test.ts
@@ -17,16 +17,28 @@ describe('condenseNumber()', () => {
     expect(condenseNumber(1500000, 'de')).toBe(`1 Mio'.'`);
   });
 
-  it('rounds down', () => {
+  it('rounds down by default', () => {
     expect(condenseNumber(1900000, 'es')).toBe('1 M');
   });
 
+  it('rounds down if specified', () => {
+    expect(condenseNumber(1900000, 'es', {roundingRule: 'down'})).toBe('1 M');
+  });
+
+  it('rounds up if specified', () => {
+    expect(condenseNumber(1900000, 'es', {roundingRule: 'up'})).toBe('2 M');
+  });
+
+  it('rounds automatically if specified', () => {
+    expect(condenseNumber(1900000, 'es', {roundingRule: 'auto'})).toBe('2 M');
+  });
+
   it('includes the provided precision when it is significant', () => {
-    expect(condenseNumber(1500000, 'es', 1)).toBe('1,5 M');
+    expect(condenseNumber(1500000, 'es', {maxPrecision: 1})).toBe('1,5 M');
   });
 
   it('does not include the provided precision when it is insignificant', () => {
-    expect(condenseNumber(1000000, 'es', 1)).toBe('1 M');
+    expect(condenseNumber(1000000, 'es', {maxPrecision: 1})).toBe('1 M');
   });
 
   it('handles negative numbers properly', () => {
@@ -38,6 +50,6 @@ describe('condenseNumber()', () => {
   });
 
   it('does not apply precision to Intl formatting when the locale is not supported', () => {
-    expect(condenseNumber(-150000, 'IN', 2)).toBe('-150.000');
+    expect(condenseNumber(-150000, 'IN', {maxPrecision: 2})).toBe('-150.000');
   });
 });

--- a/src/tests/set-precision.test.ts
+++ b/src/tests/set-precision.test.ts
@@ -1,0 +1,33 @@
+import {setPrecision} from '../set-precision';
+
+describe('setPrecision()', () => {
+  it('rounds up', () => {
+    const actual = setPrecision(10.5, 0, 'up');
+    expect(actual).toEqual(11);
+  });
+
+  it('rounds down', () => {
+    const actual = setPrecision(10.5, 0, 'down');
+    expect(actual).toEqual(10);
+  });
+
+  it('rounds down when rounding is "auto" the lower number is closest', () => {
+    const actual = setPrecision(10.2, 0, 'auto');
+    expect(actual).toEqual(10);
+  });
+
+  it('rounds up when rounding is "auto" the higher number is closest', () => {
+    const actual = setPrecision(10.7, 0, 'auto');
+    expect(actual).toEqual(11);
+  });
+
+  it('sets precision', () => {
+    const actual = setPrecision(10.518, 1, 'down');
+    expect(actual).toEqual(10.5);
+  });
+
+  it('sets precision and rounds', () => {
+    const actual = setPrecision(10.989, 2, 'auto');
+    expect(actual).toEqual(10.99);
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/Shopify/condense-number/issues/20

- Changes `precision` option to `maxPrecision` since it's more in line with what it actually does, since it doesn't apply precision if it would just be .0
- Adds an options object for `maxPrecision` and `roundingRule`, which defaults to `down` but can also be `up` or `auto`
- Updates + adds tests
- Updates + adds documentation 