### PR TITLE
Fix condense-currency to handle locale region codes

### DIFF
--- a/src/condense-currency.ts
+++ b/src/condense-currency.ts
@@ -1,4 +1,4 @@
-import {formats, symbols, isSupportedLocale} from './formats';
+import {formats, symbols, getSafeLocaleFormat} from './formats';
 import {condenseNumberToParts, RoundingRule} from './condense-number-to-parts';
 
 interface Options {
@@ -13,8 +13,9 @@ export function condenseCurrency(
   options: Partial<Options> = {},
 ) {
   const {maxPrecision = 0, roundingRule = 'down'} = options;
+  const safeLocale = getSafeLocaleFormat(locale);
 
-  if (!isSupportedLocale(locale)) {
+  if (safeLocale == null) {
     return new Intl.NumberFormat(locale, {
       style: 'currency',
       currency: currencyCode,
@@ -23,12 +24,12 @@ export function condenseCurrency(
 
   const {sign, number, abbreviation} = condenseNumberToParts(
     value,
-    locale,
+    safeLocale,
     maxPrecision,
     roundingRule,
   );
 
-  const localeInfo = formats[locale];
+  const localeInfo = formats[safeLocale];
   const currencyFormatsForLocale = localeInfo.number.patterns.currency;
 
   const symbolsForLocale = symbols[localeInfo.number.symbols];

--- a/src/tests/condense-currency.test.ts
+++ b/src/tests/condense-currency.test.ts
@@ -55,9 +55,13 @@ describe('condenseCurrency()', () => {
     expect(condenseCurrency(150000, 'en', 'abc')).toBe('ABC150K');
   });
 
+  it('supports locales with a region locale code', () => {
+    expect(condenseCurrency(150000, 'en-CA', 'CAD')).toBe('CA$150K');
+  });
+
   it('does not apply precision to Intl formatting when the locale is not supported', () => {
-    expect(condenseCurrency(150000, 'en-CA', 'USD', {maxPrecision: 1})).toBe(
-      'US$150,000.00',
+    expect(condenseCurrency(150000, 'zzz', 'CAD', {maxPrecision: 1})).toBe(
+      'CA$150,000.00',
     );
   });
 });


### PR DESCRIPTION
This PR adds a fix to `condense-currency` that handles country codes within the locale (e.g. `en-CA`). It was previously added to `condense-number`(https://github.com/Shopify/condense-number/pull/60).