### PR TITLE
CI fixes for setting up Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: 🏗 Setup Node
-      uses: actions/setup-node@v1.1.0
+      uses: actions/setup-node@v1.4.4
       with:
         version: 8.10.0
         


### PR DESCRIPTION
This PR resolves https://github.com/Shopify/condense-number/issues/67 to fix the CI. `setup-node@v1.4.4` is being used in line with polaris-viz.

This PR would be followed up by the PR to update node version to 12.20.1 to be up to terms with shopify/web.