### PR TITLE
Update slack channel name

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,5 +3,5 @@ security:
   data_management:
     contains_pii: false
 slack_channels:
-- analytical-standards-eng
+- ci-analytical-standards-rnd
 - commerce-intel-insights


### PR DESCRIPTION
Closes Shopify/services#1993...again 😆  we recently renamed `analytical-standards-eng` to `ci-analytical-standards-rnd`.