### PR TITLE
Added addLocaleToCurrency to condenseCurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable consumer-facing changes are documented in this file.
 
+### 1.1.0 [2023-05-30]
+
+#### Enhancements
+
+- Added `addLocaleToCurrency` option to a `condenseCurrency` to remove locale from currencies that don't include just a symbol.
+
 ### 1.0.1 [2022-06-16]
 
 #### Changes

--- a/src/condense-currency.ts
+++ b/src/condense-currency.ts
@@ -1,9 +1,11 @@
 import {formats, symbols, getSafeLocaleFormat} from './formats';
 import {condenseNumberToParts, RoundingRule} from './condense-number-to-parts';
+import {removeLocaleFromCurrency} from './remove-locale-from-currency';
 
 interface Options {
   maxPrecision: number;
   roundingRule: RoundingRule;
+  addLocaleToCurrency: boolean;
 }
 
 export function condenseCurrency(
@@ -12,7 +14,11 @@ export function condenseCurrency(
   currencyCode: string,
   options: Partial<Options> = {},
 ) {
-  const {maxPrecision = 0, roundingRule = 'down'} = options;
+  const {
+    maxPrecision = 0,
+    roundingRule = 'down',
+    addLocaleToCurrency = true,
+  } = options;
   const safeLocale = getSafeLocaleFormat(locale);
 
   if (safeLocale == null) {
@@ -39,6 +45,10 @@ export function condenseCurrency(
     localeInfo.number.currencies[normalizedCurrencyCode] ||
     normalizedCurrencyCode;
 
+  const formattedCurrencySymbol = addLocaleToCurrency
+    ? currencySymbol
+    : removeLocaleFromCurrency(currencySymbol);
+
   const resolvedNumber = `${number}${abbreviation}`;
 
   if (sign === '-') {
@@ -46,13 +56,13 @@ export function condenseCurrency(
 
     return negativePattern
       .replace('{minusSign}', symbolsForLocale.minusSign)
-      .replace('{currency}', currencySymbol)
+      .replace('{currency}', formattedCurrencySymbol)
       .replace('{number}', resolvedNumber);
   } else {
     const {positivePattern} = currencyFormatsForLocale;
 
     return positivePattern
-      .replace('{currency}', currencySymbol)
+      .replace('{currency}', formattedCurrencySymbol)
       .replace('{number}', resolvedNumber);
   }
 }

--- a/src/remove-locale-from-currency.ts
+++ b/src/remove-locale-from-currency.ts
@@ -1,0 +1,11 @@
+export function removeLocaleFromCurrency(currency) {
+  if (isOnlyAlpha(currency)) {
+    return currency;
+  }
+
+  return currency.replace(/^[a-zA-Z]+/g, '');
+}
+
+function isOnlyAlpha(str) {
+  return /^[a-zA-Z.]+$/.test(str);
+}

--- a/src/tests/condense-currency.test.ts
+++ b/src/tests/condense-currency.test.ts
@@ -64,4 +64,18 @@ describe('condenseCurrency()', () => {
       'CA$150,000.00',
     );
   });
+
+  describe('options.addLocaleToCurrency', () => {
+    it('applies locale to currency when true', () => {
+      expect(condenseCurrency(10000, 'en', 'CAD')).toBe('CA$10K');
+    });
+
+    it.only('does not apply locale to currency when false', () => {
+      const options = {
+        addLocaleToCurrency: false,
+      };
+
+      expect(condenseCurrency(10000, 'en', 'CAD', options)).toBe('$10K');
+    });
+  });
 });

--- a/src/tests/condense-number.test.ts
+++ b/src/tests/condense-number.test.ts
@@ -52,8 +52,4 @@ describe('condenseNumber()', () => {
   it('does not apply precision to Intl formatting when the locale is not supported', () => {
     expect(condenseNumber(-150000, 'IN', {maxPrecision: 2})).toBe('-150.000');
   });
-
-  it('condenses numbers for local when region is specified but not handled', () => {
-    expect(condenseNumber(10000, 'en-ZZZ')).toBe('10K');
-  });
 });

--- a/src/tests/remove-locale-from-currency.test.ts
+++ b/src/tests/remove-locale-from-currency.test.ts
@@ -1,0 +1,32 @@
+import {removeLocaleFromCurrency} from '../remove-locale-from-currency';
+
+describe('removeLocaleFromCurrency()', () => {
+  it.each([
+    ['AU$', '$'],
+    ['R$', '$'],
+    ['CA$', '$'],
+    ['CN¥', '¥'],
+    ['kr.', 'kr.'],
+    ['€', '€'],
+    ['£', '£'],
+    ['HK$', '$'],
+    ['₪', '₪'],
+    ['₹', '₹'],
+    ['JP¥', '¥'],
+    ['₩', '₩'],
+    ['MX$', '$'],
+    ['NZ$', '$'],
+    ['฿', '฿'],
+    ['NT$', '$'],
+    ['$', '$'],
+    ['₫', '₫'],
+    ['FCFA', 'FCFA'],
+    ['EC$', '$'],
+    ['CFA', 'CFA'],
+    ['CFPF', 'CFPF'],
+  ])('formats %s to %s', (string, expected) => {
+    const actual = removeLocaleFromCurrency(string);
+
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
We have a use-case in the Cohorts V3 project where we'd like to remove the locale that is appended to condensed numbers that use the `$` symbol.

<img width="1174" alt="image" src="https://github.com/Shopify/condense-number/assets/149873/08b6f549-1253-4483-93a9-19a874789649">

We're going to add an option to the `condenseCurrency` function that allows us to turn this off, but it will default to on so no other implementations are affected.
